### PR TITLE
fix: missing index on order

### DIFF
--- a/database/migrations/create_page_builder_blocks_table.php.stub
+++ b/database/migrations/create_page_builder_blocks_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
         Schema::create('page_builder_blocks', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->string('block_type');
-            $table->unsignedTinyInteger('order');
+            $table->unsignedTinyInteger('order')->index();
             $table->morphs('page_builder_blockable', indexName: 'page_builder_blockable_index');
             $table->json('data')->nullable();
             $table->timestamps();


### PR DESCRIPTION
sorting by order would cause sort buffer size getting reached, with error: Memory allocation error: 1038 Out of sort memory, consider increasing server sort buffer size﻿﻿
